### PR TITLE
NippoNavbar がトップに表示され続ける挙動を無くす

### DIFF
--- a/src/app/[slug]/[date]/page.tsx
+++ b/src/app/[slug]/[date]/page.tsx
@@ -29,7 +29,7 @@ export default async function Page({ params }: Props) {
 
   return (
     <div className="drop-shadow-sm">
-      <div className="min-h-[500px] max-w-[1024px] mx-auto flex flex-col-reverse md:flex-row gap-[16px] md:gap-[48px]">
+      <div className="min-h-[500px] max-w-[1024px] mx-auto flex gap-[16px] md:gap-[48px]">
         <div className="px-[8px] pt-[16px] pb-[32px] w-[100%]">
           <ObjectiveStickyHeader objective={objective} />
           <p className="mt-[32px] text-xl font-bold mb-[8px] text-gray-700">{dateString}</p>

--- a/src/app/[slug]/[date]/page.tsx
+++ b/src/app/[slug]/[date]/page.tsx
@@ -8,6 +8,7 @@ import { fetchMe } from '~/app/_actions/userActions';
 import { NippoEditor } from '~/app/_components/domains/Nippo/NippoEditor';
 import { Tabs } from '~/app/_components/uiParts/Tabs';
 import { getDateString } from '~/libs/getDateString';
+import { ObjectiveStickyHeader } from '~/app/_components/domains/Objective/ObjectiveStickyHeader';
 
 type Props = { params: { slug: string; date: string } };
 
@@ -30,7 +31,7 @@ export default async function Page({ params }: Props) {
     <div className="drop-shadow-sm">
       <div className="min-h-[500px] max-w-[1024px] mx-auto flex flex-col-reverse md:flex-row gap-[16px] md:gap-[48px]">
         <div className="px-[8px] pt-[16px] pb-[32px] w-[100%]">
-          <h1 className="text-2xl font-bold pb-[8px] border-b-1">{objective.name}</h1>
+          <ObjectiveStickyHeader objective={objective} />
           <p className="mt-[32px] text-xl font-bold mb-[8px] text-gray-700">{dateString}</p>
           {currentUser?._id === objective.createdUserId ? (
             <Tabs

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Link } from '@nextui-org/link';
 import { Metadata } from 'next';
 import { getObjectiveBySlug, getObjectiveNippos } from '../_actions/objectiveActions';
 import { URLS } from '../_constants/urls';
+import { ObjectiveStickyHeader } from '../_components/domains/Objective/ObjectiveStickyHeader';
 import { NippoEditor } from '~/app/_components/domains/Nippo/NippoEditor';
 import { NippoPreview } from '~/app/_components/domains/Nippo/NippoPreview';
 import { fetchMe } from '~/app/_actions/userActions';
@@ -27,7 +28,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
     <div className="drop-shadow-sm">
       <div className="min-h-[500px] max-w-[1024px] mx-auto flex flex-col-reverse md:flex-row gap-[16px] md:gap-[48px]">
         <div className="px-[8px] pt-[16px] pb-[32px] w-[100%]">
-          <h1 className="text-2xl font-bold pb-[8px] border-b-1">{objective.name}</h1>
+          <ObjectiveStickyHeader objective={objective} />
           <p className="mt-[32px] text-xl font-bold mb-[8px] text-gray-700">{format(getCurrentDate(), 'yyyy年 MM月dd日')}</p>
           {currentUser?._id === objective.createdUserId ? (
             <div className="h-[500px]">

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -26,7 +26,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
   return (
     <div className="drop-shadow-sm">
-      <div className="min-h-[500px] max-w-[1024px] mx-auto flex flex-col-reverse md:flex-row gap-[16px] md:gap-[48px]">
+      <div className="min-h-[500px] max-w-[1024px] mx-auto flex gap-[16px] md:gap-[48px]">
         <div className="px-[8px] pt-[16px] pb-[32px] w-[100%]">
           <ObjectiveStickyHeader objective={objective} />
           <p className="mt-[32px] text-xl font-bold mb-[8px] text-gray-700">{format(getCurrentDate(), 'yyyy年 MM月dd日')}</p>

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -29,7 +29,9 @@ export default async function Page({ params }: { params: { slug: string } }) {
       <div className="min-h-[500px] max-w-[1024px] mx-auto flex gap-[16px] md:gap-[48px]">
         <div className="px-[8px] pt-[16px] pb-[32px] w-[100%]">
           <ObjectiveStickyHeader objective={objective} />
-          <p className="mt-[32px] text-xl font-bold mb-[8px] text-gray-700">{format(getCurrentDate(), 'yyyy年 MM月dd日')}</p>
+          <Link href={URLS.SLUG_DATE(objective.slug, format(getCurrentDate(), 'yyyy-MM-dd'))} className="cursor-pointer">
+            <p className="mt-[32px] text-xl font-bold mb-[8px] text-gray-700">{format(getCurrentDate(), 'yyyy年 MM月dd日')}</p>
+          </Link>
           {currentUser?._id === objective.createdUserId ? (
             <div className="h-[500px]">
               <NippoEditor objectiveId={objective._id} date={format(getCurrentDate(), 'yyyy-MM-dd')} nippo={todayNippo} />

--- a/src/app/_components/domains/Objective/ObjectiveStickyHeader/ObjectiveStickyHeader.tsx
+++ b/src/app/_components/domains/Objective/ObjectiveStickyHeader/ObjectiveStickyHeader.tsx
@@ -1,4 +1,6 @@
+import { Link } from '@nextui-org/link';
 import { FC } from 'react';
+import { URLS } from '~/app/_constants/urls';
 import { Objective } from '~/domains/Objective';
 
 type Props = {
@@ -7,7 +9,9 @@ type Props = {
 export const ObjectiveStickyHeader: FC<Props> = ({ objective }) => {
   return (
     <h1 className="text-xl md:text-2xl font-bold py-[8px] border-b-1 sticky md:static mx-[-8px] px-[8px] md:mx-[0px] md:px-[0px] top-0 z-10 bg-slate-50">
-      {objective.name}
+      <Link href={URLS.SLUG(objective.slug)} className="cursor-pointer text-inherit">
+        {objective.name}
+      </Link>
     </h1>
   );
 };

--- a/src/app/_components/domains/Objective/ObjectiveStickyHeader/ObjectiveStickyHeader.tsx
+++ b/src/app/_components/domains/Objective/ObjectiveStickyHeader/ObjectiveStickyHeader.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { Objective } from '~/domains/Objective';
+
+type Props = {
+  objective: Objective;
+};
+export const ObjectiveStickyHeader: FC<Props> = ({ objective }) => {
+  return (
+    <h1 className="text-xl md:text-2xl font-bold py-[8px] border-b-1 sticky md:static mx-[-8px] px-[8px] md:mx-[0px] md:px-[0px] top-0 z-10 bg-slate-50">
+      {objective.name}
+    </h1>
+  );
+};

--- a/src/app/_components/domains/Objective/ObjectiveStickyHeader/index.ts
+++ b/src/app/_components/domains/Objective/ObjectiveStickyHeader/index.ts
@@ -1,0 +1,1 @@
+export { ObjectiveStickyHeader } from './ObjectiveStickyHeader';

--- a/src/app/_components/layouts/NippoNavbar/NippoNavbar.tsx
+++ b/src/app/_components/layouts/NippoNavbar/NippoNavbar.tsx
@@ -9,7 +9,7 @@ export const NippoNavbar: FC = async () => {
   const { currentUser } = await fetchMe();
 
   return (
-    <Navbar isBordered isBlurred={false}>
+    <Navbar isBordered isBlurred={false} position="static">
       <NavbarBrand>
         <Link href="/" color="foreground" className="font-bold">
           みんなの日報


### PR DESCRIPTION

## やったこと
- 日報一覧画面や、日報詳細画面では日報のワークスペースの情報がトップに表示され続けるようにする
- 表示する情報は現在日報のワークスペースの名前くらいしかない (この日報だと サメがむの日報)
